### PR TITLE
Underlying() fix for fungible options + test fixups / coverage + drop dead code

### DIFF
--- a/src/OptionSettlement.sol
+++ b/src/OptionSettlement.sol
@@ -426,7 +426,7 @@ contract OptionSettlementEngine is ERC1155, IOptionSettlementEngine {
 
         // token ID is an option
         if (_tokenIdL96b == 0) {
-            bool expired = (optionRecord.expiryTimestamp > block.timestamp);
+            bool expired = (optionRecord.expiryTimestamp <= block.timestamp);
             underlyingPositions = Underlying({
                 underlyingAsset: optionRecord.underlyingAsset,
                 underlyingPosition: expired ? int256(0) : int256(uint256(optionRecord.underlyingAmount)),

--- a/src/OptionSettlement.sol
+++ b/src/OptionSettlement.sol
@@ -184,12 +184,12 @@ contract OptionSettlementEngine is ERC1155, IOptionSettlementEngine {
 
         // Make sure that expiry is at least 24 hours from now
         if (expiryTimestamp < (block.timestamp + 1 days)) {
-            revert ExpiryTooSoon(optionId, expiryTimestamp); // TODO what is the point of including optionId that will never get created here?
+            revert ExpiryWindowTooShort(expiryTimestamp);
         }
 
         // Ensure the exercise window is at least 24 hours
         if (expiryTimestamp < (exerciseTimestamp + 1 days)) {
-            revert ExerciseWindowTooShort();
+            revert ExerciseWindowTooShort(exerciseTimestamp);
         }
 
         // The exercise and underlying assets can't be the same

--- a/src/OptionSettlement.sol
+++ b/src/OptionSettlement.sol
@@ -294,10 +294,6 @@ contract OptionSettlementEngine is ERC1155, IOptionSettlementEngine {
             // retrieve claim
             Claim storage existingClaim = _claim[claimId];
 
-            if (existingClaim.claimed) {
-                revert AlreadyClaimed(claimId);
-            }
-
             existingClaim.amountWritten += amount;
         }
         uint16 bucketIndex = _addOrUpdateClaimBucket(_optionIdU160b, amount);
@@ -387,11 +383,6 @@ contract OptionSettlementEngine is ERC1155, IOptionSettlementEngine {
         }
 
         Claim storage claimRecord = _claim[claimId];
-
-        if (claimRecord.claimed) {
-            revert AlreadyClaimed(claimId);
-        }
-
         Option storage optionRecord = _option[_optionId];
 
         if (optionRecord.expiryTimestamp > block.timestamp) {

--- a/src/interfaces/IOptionSettlementEngine.sol
+++ b/src/interfaces/IOptionSettlementEngine.sol
@@ -33,13 +33,15 @@ interface IOptionSettlementEngine {
 
     /**
      * @notice The expiry timestamp is less than 24 hours from now.
-     * @param optionId Supplied option ID.
      * @param expiry Timestamp of expiry
      */
-    error ExpiryTooSoon(uint256 optionId, uint40 expiry);
+    error ExpiryWindowTooShort(uint40 expiry);
 
-    /// @notice The option exercise window is less than 24 hours long.
-    error ExerciseWindowTooShort();
+    /**
+     * @notice The option exercise window is less than 24 hours long.
+     * @param exercise The timestamp supplied for exercise.
+     */
+    error ExerciseWindowTooShort(uint40 exercise);
 
     /**
      * @notice The assets specified are invalid or duplicate.


### PR DESCRIPTION
- Fix underlying() to correctly return info for fungible options
- Remove dead / unreachable code
- Stdize test naming for reverts
- Increase coverage
- Remove duplicate tests

Addresses #97 