### PR TITLE
Support off-chain claim accounting via bucket events

### DIFF
--- a/src/OptionSettlementEngine.sol
+++ b/src/OptionSettlementEngine.sol
@@ -814,7 +814,7 @@ contract OptionSettlementEngine is ERC1155, IOptionSettlementEngine {
             emit BucketAssignedExercise(optionId, bucketIndex, amountPresentlyExercised);
 
             if (amount != 0) {
-                // Get an additional bucket.
+                // Get an additional bucket, because we still have options to exercise.
                 exerciseIndex = (exerciseIndex + 1) % numUnexercisedBuckets;
             }
         }

--- a/src/OptionSettlementEngine.sol
+++ b/src/OptionSettlementEngine.sol
@@ -450,9 +450,9 @@ contract OptionSettlementEngine is ERC1155, IOptionSettlementEngine {
             // Add claim bucket indices.
             _addOrUpdateClaimIndex(optionTypeStates[optionKey], nextClaimKey, bucketIndex, amount);
 
-            // TODO resolve stack too deep.
-            // Emit event about options written on a new claim.
-            // emit OptionsWritten(encodedOptionId, msg.sender, tokenId, bucketIndex, amount);
+            // Emit events about options written on a new claim.
+            emit OptionsWritten(encodedOptionId, msg.sender, tokenId, amount);
+            emit BucketWrittenInto(encodedOptionId, bucketIndex, amount);
 
             // Transfer in the requisite underlying asset amount.
             SafeTransferLib.safeTransferFrom(ERC20(underlyingAsset), msg.sender, address(this), (rxAmount + fee));
@@ -479,9 +479,9 @@ contract OptionSettlementEngine is ERC1155, IOptionSettlementEngine {
             // Add claim bucket indices.
             _addOrUpdateClaimIndex(optionTypeStates[optionKey], claimKey, bucketIndex, amount);
 
-            // TODO resolve stack too deep.
-            // Emit event about options written on existing claim.
-            // emit OptionsWritten(encodedOptionId, msg.sender, tokenId, bucketIndex, amount);
+            // Emit events about options written on existing claim.
+            emit OptionsWritten(encodedOptionId, msg.sender, tokenId, amount);
+            emit BucketWrittenInto(encodedOptionId, bucketIndex, amount);
 
             // Transfer in the requisite underlying asset amount.
             SafeTransferLib.safeTransferFrom(ERC20(underlyingAsset), msg.sender, address(this), (rxAmount + fee));

--- a/src/OptionSettlementEngine.sol
+++ b/src/OptionSettlementEngine.sol
@@ -812,7 +812,7 @@ contract OptionSettlementEngine is ERC1155, IOptionSettlementEngine {
             bucketInfo.amountExercised += amountPresentlyExercised;
 
             emit BucketAssignedExercise(optionId, bucketIndex, amountPresentlyExercised);
-            
+
             if (amount != 0) {
                 // Get an additional bucket.
                 exerciseIndex = (exerciseIndex + 1) % numUnexercisedBuckets;

--- a/src/OptionSettlementEngine.sol
+++ b/src/OptionSettlementEngine.sol
@@ -452,7 +452,7 @@ contract OptionSettlementEngine is ERC1155, IOptionSettlementEngine {
 
             // Emit events about options written on a new claim.
             emit OptionsWritten(encodedOptionId, msg.sender, tokenId, amount);
-            emit BucketWrittenInto(encodedOptionId, bucketIndex, amount);
+            emit BucketWrittenInto(encodedOptionId, tokenId, bucketIndex, amount);
 
             // Transfer in the requisite underlying asset amount.
             SafeTransferLib.safeTransferFrom(ERC20(underlyingAsset), msg.sender, address(this), (rxAmount + fee));
@@ -481,7 +481,7 @@ contract OptionSettlementEngine is ERC1155, IOptionSettlementEngine {
 
             // Emit events about options written on existing claim.
             emit OptionsWritten(encodedOptionId, msg.sender, tokenId, amount);
-            emit BucketWrittenInto(encodedOptionId, bucketIndex, amount);
+            emit BucketWrittenInto(encodedOptionId, tokenId, bucketIndex, amount);
 
             // Transfer in the requisite underlying asset amount.
             SafeTransferLib.safeTransferFrom(ERC20(underlyingAsset), msg.sender, address(this), (rxAmount + fee));

--- a/src/OptionSettlementEngine.sol
+++ b/src/OptionSettlementEngine.sol
@@ -450,8 +450,9 @@ contract OptionSettlementEngine is ERC1155, IOptionSettlementEngine {
             // Add claim bucket indices.
             _addOrUpdateClaimIndex(optionTypeStates[optionKey], nextClaimKey, bucketIndex, amount);
 
+            // TODO resolve stack too deep.
             // Emit event about options written on a new claim.
-            emit OptionsWritten(encodedOptionId, msg.sender, tokenId, amount);
+            // emit OptionsWritten(encodedOptionId, msg.sender, tokenId, bucketIndex, amount);
 
             // Transfer in the requisite underlying asset amount.
             SafeTransferLib.safeTransferFrom(ERC20(underlyingAsset), msg.sender, address(this), (rxAmount + fee));
@@ -478,8 +479,9 @@ contract OptionSettlementEngine is ERC1155, IOptionSettlementEngine {
             // Add claim bucket indices.
             _addOrUpdateClaimIndex(optionTypeStates[optionKey], claimKey, bucketIndex, amount);
 
+            // TODO resolve stack too deep.
             // Emit event about options written on existing claim.
-            emit OptionsWritten(encodedOptionId, msg.sender, tokenId, amount);
+            // emit OptionsWritten(encodedOptionId, msg.sender, tokenId, bucketIndex, amount);
 
             // Transfer in the requisite underlying asset amount.
             SafeTransferLib.safeTransferFrom(ERC20(underlyingAsset), msg.sender, address(this), (rxAmount + fee));
@@ -806,6 +808,10 @@ contract OptionSettlementEngine is ERC1155, IOptionSettlementEngine {
             }
             bucketInfo.amountExercised += amountPresentlyExercised;
 
+            // TODO fix specific values.
+            emit BucketAssignedExercise(123, bucketIndex, 456);
+
+            // TODO say what we're doing here.
             if (amount != 0) {
                 exerciseIndex = (exerciseIndex + 1) % numUnexercisedBuckets;
             }

--- a/src/interfaces/IOptionSettlementEngine.sol
+++ b/src/interfaces/IOptionSettlementEngine.sol
@@ -10,24 +10,8 @@ interface IOptionSettlementEngine {
     //////////////////////////////////////////////////////////////*/
 
     //
-    // Write/Redeem events
+    // New Option Type events
     //
-
-    /**
-     * @notice Emitted when a claim is redeemed.
-     * @param optionId The token id of the option type of the claim being redeemed.
-     * @param claimId The token id of the claim being redeemed.
-     * @param redeemer The address redeeming the claim.
-     * @param exerciseAmountRedeemed The amount of the option.exerciseAsset redeemed.
-     * @param underlyingAmountRedeemed The amount of option.underlyingAsset redeemed.
-     */
-    event ClaimRedeemed(
-        uint256 indexed claimId,
-        uint256 indexed optionId,
-        address indexed redeemer,
-        uint256 exerciseAmountRedeemed,
-        uint256 underlyingAmountRedeemed
-    );
 
     /**
      * @notice Emitted when a new option type is created.
@@ -50,16 +34,49 @@ interface IOptionSettlementEngine {
     );
 
     //
-    // Exercise events
+    // Write events
     //
 
     /**
-     * @notice Emitted when a bucket is assigned exercise.
-     * @param optionId The token id of the option type exercised.
-     * @param bucketIndex The index of the bucket which is being assigned exercise.
-     * @param amountAssigned The amount of options contracts assigned exercise in the given bucket.
+     * @notice Emitted when new options contracts are written.
+     * @param optionId The token id of the option type written.
+     * @param writer The address of the writer.
+     * @param claimId The claim token id of the new or existing short position written against.
+     * @param amount The amount of options contracts written.
      */
-    event BucketAssignedExercise(uint256 indexed optionId, uint96 indexed bucketIndex, uint112 amountAssigned);
+    event OptionsWritten(uint256 indexed optionId, address indexed writer, uint256 indexed claimId, uint112 amount);
+
+    /**
+     * @notice Emitted when options contracts are written into a bucket.
+     * @param optionId The token id of the option type written.
+     * @param bucketIndex The index of the bucket to which the options were written.
+     * @param amount The amount of options contracts written.
+     */
+    event BucketWrittenInto(uint256 indexed optionId, uint96 bucketIndex, uint112 amount);
+
+    //
+    // Redeem events
+    //
+
+    /**
+     * @notice Emitted when a claim is redeemed.
+     * @param optionId The token id of the option type of the claim being redeemed.
+     * @param claimId The token id of the claim being redeemed.
+     * @param redeemer The address redeeming the claim.
+     * @param exerciseAmountRedeemed The amount of the option.exerciseAsset redeemed.
+     * @param underlyingAmountRedeemed The amount of option.underlyingAsset redeemed.
+     */
+    event ClaimRedeemed(
+        uint256 indexed claimId,
+        uint256 indexed optionId,
+        address indexed redeemer,
+        uint256 exerciseAmountRedeemed,
+        uint256 underlyingAmountRedeemed
+    );
+
+    //
+    // Exercise events
+    //
 
     /**
      * @notice Emitted when option contract(s) is(are) exercised.
@@ -70,16 +87,12 @@ interface IOptionSettlementEngine {
     event OptionsExercised(uint256 indexed optionId, address indexed exerciser, uint112 amount);
 
     /**
-     * @notice Emitted when new options contracts are written.
-     * @param optionId The token id of the option type written.
-     * @param writer The address of the writer.
-     * @param claimId The claim token id of the new or existing short position written against.
-     * @param bucketIndex The index of the bucket to which the claim was added.
-     * @param amount The amount of options contracts written.
+     * @notice Emitted when a bucket is assigned exercise.
+     * @param optionId The token id of the option type exercised.
+     * @param bucketIndex The index of the bucket which is being assigned exercise.
+     * @param amountAssigned The amount of options contracts assigned exercise in the given bucket.
      */
-    event OptionsWritten(
-        uint256 indexed optionId, address indexed writer, uint256 indexed claimId, uint96 bucketIndex, uint112 amount
-    );
+    event BucketAssignedExercise(uint256 indexed optionId, uint96 indexed bucketIndex, uint112 amountAssigned);
 
     //
     // Fee events

--- a/src/interfaces/IOptionSettlementEngine.sol
+++ b/src/interfaces/IOptionSettlementEngine.sol
@@ -10,7 +10,7 @@ interface IOptionSettlementEngine {
     //////////////////////////////////////////////////////////////*/
 
     //
-    // New Option Type events
+    // Write events
     //
 
     /**
@@ -32,10 +32,6 @@ interface IOptionSettlementEngine {
         uint40 exerciseTimestamp,
         uint40 indexed expiryTimestamp
     );
-
-    //
-    // Write events
-    //
 
     /**
      * @notice Emitted when new options contracts are written.

--- a/src/interfaces/IOptionSettlementEngine.sol
+++ b/src/interfaces/IOptionSettlementEngine.sol
@@ -45,10 +45,13 @@ interface IOptionSettlementEngine {
     /**
      * @notice Emitted when options contracts are written into a bucket.
      * @param optionId The token id of the option type written.
+     * @param claimId The claim token id of the new or existing short position written against.
      * @param bucketIndex The index of the bucket to which the options were written.
      * @param amount The amount of options contracts written.
      */
-    event BucketWrittenInto(uint256 indexed optionId, uint96 bucketIndex, uint112 amount);
+    event BucketWrittenInto(
+        uint256 indexed optionId, uint256 indexed claimId, uint96 indexed bucketIndex, uint112 amount
+    );
 
     //
     // Redeem events

--- a/src/interfaces/IOptionSettlementEngine.sol
+++ b/src/interfaces/IOptionSettlementEngine.sol
@@ -54,6 +54,14 @@ interface IOptionSettlementEngine {
     //
 
     /**
+     * @notice Emitted when a bucket is assigned exercise.
+     * @param optionId The token id of the option type exercised.
+     * @param bucketIndex The index of the bucket which is being assigned exercise.
+     * @param amountAssigned The amount of options contracts assigned exercise in the given bucket.
+     */
+    event BucketAssignedExercise(uint256 indexed optionId, uint96 indexed bucketIndex, uint112 amountAssigned);
+
+    /**
      * @notice Emitted when option contract(s) is(are) exercised.
      * @param optionId The token id of the option type exercised.
      * @param exerciser The address that exercised the option contract(s).
@@ -66,9 +74,12 @@ interface IOptionSettlementEngine {
      * @param optionId The token id of the option type written.
      * @param writer The address of the writer.
      * @param claimId The claim token id of the new or existing short position written against.
+     * @param bucketIndex The index of the bucket to which the claim was added.
      * @param amount The amount of options contracts written.
      */
-    event OptionsWritten(uint256 indexed optionId, address indexed writer, uint256 indexed claimId, uint112 amount);
+    event OptionsWritten(
+        uint256 indexed optionId, address indexed writer, uint256 indexed claimId, uint96 bucketIndex, uint112 amount
+    );
 
     //
     // Fee events

--- a/test/OptionSettlementEngine.unit.t.sol
+++ b/test/OptionSettlementEngine.unit.t.sol
@@ -526,16 +526,17 @@ contract OptionSettlementUnitTest is BaseEngineTest {
     function test_write_whenNewClaim() public {
         uint112 amountWritten = 5;
         uint256 expectedFee = _calculateFee(testUnderlyingAmount * amountWritten);
+        uint256 expectedClaimId = testOptionId + 1;
         uint96 expectedBucketIndex = 0;
 
         vm.expectEmit(true, true, true, true);
         emit FeeAccrued(testOptionId, testUnderlyingAsset, ALICE, expectedFee);
 
         vm.expectEmit(true, true, true, true);
-        emit OptionsWritten(testOptionId, ALICE, testOptionId + 1, amountWritten);
+        emit OptionsWritten(testOptionId, ALICE, expectedClaimId, amountWritten);
 
         vm.expectEmit(true, true, true, true);
-        emit BucketWrittenInto(testOptionId, expectedBucketIndex, 5);
+        emit BucketWrittenInto(testOptionId, expectedClaimId, expectedBucketIndex, 5);
 
         vm.prank(ALICE);
         uint256 claimId = engine.write(testOptionId, amountWritten);
@@ -566,7 +567,7 @@ contract OptionSettlementUnitTest is BaseEngineTest {
         emit OptionsWritten(testOptionId, ALICE, claimId, 5);
 
         vm.expectEmit(true, true, true, true);
-        emit BucketWrittenInto(testOptionId, expectedBucketIndex, 5);
+        emit BucketWrittenInto(testOptionId, claimId, expectedBucketIndex, 5);
 
         // Alice writes 5 more options on existing claim
         vm.prank(ALICE);
@@ -587,16 +588,17 @@ contract OptionSettlementUnitTest is BaseEngineTest {
     }
 
     function test_write_whenFeeOff() public {
+        uint256 expectedClaimId = testOptionId + 1;
         uint96 expectedBucketIndex = 0;
 
         vm.prank(FEE_TO);
         engine.setFeesEnabled(false);
 
         vm.expectEmit(true, true, true, true);
-        emit OptionsWritten(testOptionId, ALICE, testOptionId + 1, 5);
+        emit OptionsWritten(testOptionId, ALICE, expectedClaimId, 5);
 
         vm.expectEmit(true, true, true, true);
-        emit BucketWrittenInto(testOptionId, expectedBucketIndex, 5);
+        emit BucketWrittenInto(testOptionId, expectedClaimId, expectedBucketIndex, 5);
 
         vm.prank(ALICE);
         uint256 claimId = engine.write(testOptionId, 5);

--- a/test/OptionSettlementEngine.unit.t.sol
+++ b/test/OptionSettlementEngine.unit.t.sol
@@ -532,7 +532,10 @@ contract OptionSettlementUnitTest is BaseEngineTest {
         emit FeeAccrued(testOptionId, testUnderlyingAsset, ALICE, expectedFee);
 
         vm.expectEmit(true, true, true, true);
-        emit OptionsWritten(testOptionId, ALICE, testOptionId + 1, expectedBucketIndex, amountWritten);
+        emit OptionsWritten(testOptionId, ALICE, testOptionId + 1, amountWritten);
+
+        vm.expectEmit(true, true, true, true);
+        emit BucketWrittenInto(testOptionId, expectedBucketIndex, 5);
 
         vm.prank(ALICE);
         uint256 claimId = engine.write(testOptionId, amountWritten);
@@ -560,7 +563,10 @@ contract OptionSettlementUnitTest is BaseEngineTest {
         emit FeeAccrued(testOptionId, testUnderlyingAsset, ALICE, _calculateFee(testUnderlyingAmount * 5));
 
         vm.expectEmit(true, true, true, true);
-        emit OptionsWritten(testOptionId, ALICE, claimId, expectedBucketIndex, 5);
+        emit OptionsWritten(testOptionId, ALICE, claimId, 5);
+
+        vm.expectEmit(true, true, true, true);
+        emit BucketWrittenInto(testOptionId, expectedBucketIndex, 5);
 
         // Alice writes 5 more options on existing claim
         vm.prank(ALICE);
@@ -587,7 +593,10 @@ contract OptionSettlementUnitTest is BaseEngineTest {
         engine.setFeesEnabled(false);
 
         vm.expectEmit(true, true, true, true);
-        emit OptionsWritten(testOptionId, ALICE, testOptionId + 1, expectedBucketIndex, 5);
+        emit OptionsWritten(testOptionId, ALICE, testOptionId + 1, 5);
+
+        vm.expectEmit(true, true, true, true);
+        emit BucketWrittenInto(testOptionId, expectedBucketIndex, 5);
 
         vm.prank(ALICE);
         uint256 claimId = engine.write(testOptionId, 5);

--- a/test/OptionSettlementEngine.unit.t.sol
+++ b/test/OptionSettlementEngine.unit.t.sol
@@ -526,12 +526,13 @@ contract OptionSettlementUnitTest is BaseEngineTest {
     function test_write_whenNewClaim() public {
         uint112 amountWritten = 5;
         uint256 expectedFee = _calculateFee(testUnderlyingAmount * amountWritten);
+        uint96 expectedBucketIndex = 0;
 
         vm.expectEmit(true, true, true, true);
         emit FeeAccrued(testOptionId, testUnderlyingAsset, ALICE, expectedFee);
 
         vm.expectEmit(true, true, true, true);
-        emit OptionsWritten(testOptionId, ALICE, testOptionId + 1, amountWritten);
+        emit OptionsWritten(testOptionId, ALICE, testOptionId + 1, expectedBucketIndex, amountWritten);
 
         vm.prank(ALICE);
         uint256 claimId = engine.write(testOptionId, amountWritten);
@@ -553,12 +554,13 @@ contract OptionSettlementUnitTest is BaseEngineTest {
         // Alice writes 1 option
         vm.prank(ALICE);
         uint256 claimId = engine.write(testOptionId, 1);
+        uint96 expectedBucketIndex = 0;
 
         vm.expectEmit(true, true, true, true);
         emit FeeAccrued(testOptionId, testUnderlyingAsset, ALICE, _calculateFee(testUnderlyingAmount * 5));
 
         vm.expectEmit(true, true, true, true);
-        emit OptionsWritten(testOptionId, ALICE, claimId, 5);
+        emit OptionsWritten(testOptionId, ALICE, claimId, expectedBucketIndex, 5);
 
         // Alice writes 5 more options on existing claim
         vm.prank(ALICE);
@@ -579,11 +581,13 @@ contract OptionSettlementUnitTest is BaseEngineTest {
     }
 
     function test_write_whenFeeOff() public {
+        uint96 expectedBucketIndex = 0;
+
         vm.prank(FEE_TO);
         engine.setFeesEnabled(false);
 
         vm.expectEmit(true, true, true, true);
-        emit OptionsWritten(testOptionId, ALICE, testOptionId + 1, 5);
+        emit OptionsWritten(testOptionId, ALICE, testOptionId + 1, expectedBucketIndex, 5);
 
         vm.prank(ALICE);
         uint256 claimId = engine.write(testOptionId, 5);
@@ -1009,6 +1013,10 @@ contract OptionSettlementUnitTest is BaseEngineTest {
         vm.expectEmit(true, true, true, true);
         emit FeeAccrued(testOptionId, testExerciseAsset, BOB, expectedExerciseFee);
 
+        uint96 expectedBucketIndex = 789;
+        vm.expectEmit(true, true, true, true);
+        emit BucketAssignedExercise(testOptionId, expectedBucketIndex, 789);
+
         vm.expectEmit(true, true, true, true);
         emit OptionsExercised(testOptionId, BOB, 2);
 
@@ -1056,6 +1064,10 @@ contract OptionSettlementUnitTest is BaseEngineTest {
         vm.expectEmit(true, true, true, true);
         emit FeeAccrued(testOptionId, testExerciseAsset, BOB, expectedExercise2Fee);
 
+        uint96 expectedBucketIndex = 789;
+        vm.expectEmit(true, true, true, true);
+        emit BucketAssignedExercise(testOptionId, expectedBucketIndex, 789);
+
         vm.expectEmit(true, true, true, true);
         emit OptionsExercised(testOptionId, BOB, 2);
 
@@ -1080,6 +1092,10 @@ contract OptionSettlementUnitTest is BaseEngineTest {
 
         vm.expectEmit(true, true, true, true);
         emit FeeAccrued(testOptionId, testExerciseAsset, BOB, expectedExercise3Fee);
+
+        expectedBucketIndex = 789;
+        vm.expectEmit(true, true, true, true);
+        emit BucketAssignedExercise(testOptionId, expectedBucketIndex, 789);
 
         vm.expectEmit(true, true, true, true);
         emit OptionsExercised(testOptionId, BOB, 3);

--- a/test/OptionSettlementEngine.unit.t.sol
+++ b/test/OptionSettlementEngine.unit.t.sol
@@ -1018,13 +1018,13 @@ contract OptionSettlementUnitTest is BaseEngineTest {
         // Warp to exercise
         vm.warp(testExerciseTimestamp);
 
+        uint96 expectedBucketIndex = 0;
+        vm.expectEmit(true, true, true, true);
+        emit BucketAssignedExercise(testOptionId, expectedBucketIndex, 2);
+
         uint256 expectedExerciseFee = _calculateFee(testExerciseAmount * 2);
         vm.expectEmit(true, true, true, true);
         emit FeeAccrued(testOptionId, testExerciseAsset, BOB, expectedExerciseFee);
-
-        uint96 expectedBucketIndex = 789;
-        vm.expectEmit(true, true, true, true);
-        emit BucketAssignedExercise(testOptionId, expectedBucketIndex, 789);
 
         vm.expectEmit(true, true, true, true);
         emit OptionsExercised(testOptionId, BOB, 2);
@@ -1070,12 +1070,12 @@ contract OptionSettlementUnitTest is BaseEngineTest {
         uint256 expectedExercise2Fee = _calculateFee(testExerciseAmount * 2);
         uint256 expectedExercise3Fee = _calculateFee(testExerciseAmount * 3);
 
+        uint96 expectedBucketIndex = 0;
+        vm.expectEmit(true, true, true, true);
+        emit BucketAssignedExercise(testOptionId, expectedBucketIndex, 2);
+
         vm.expectEmit(true, true, true, true);
         emit FeeAccrued(testOptionId, testExerciseAsset, BOB, expectedExercise2Fee);
-
-        uint96 expectedBucketIndex = 789;
-        vm.expectEmit(true, true, true, true);
-        emit BucketAssignedExercise(testOptionId, expectedBucketIndex, 789);
 
         vm.expectEmit(true, true, true, true);
         emit OptionsExercised(testOptionId, BOB, 2);
@@ -1099,12 +1099,12 @@ contract OptionSettlementUnitTest is BaseEngineTest {
         assertEq(engine.feeBalance(testUnderlyingAsset), expectedWriteFee, "Fee balance underlying after exercising 2");
         assertEq(engine.feeBalance(testExerciseAsset), expectedExercise2Fee, "Fee balance exercise after exercising 2");
 
+        expectedBucketIndex = 0;
+        vm.expectEmit(true, true, true, true);
+        emit BucketAssignedExercise(testOptionId, expectedBucketIndex, 3);
+
         vm.expectEmit(true, true, true, true);
         emit FeeAccrued(testOptionId, testExerciseAsset, BOB, expectedExercise3Fee);
-
-        expectedBucketIndex = 789;
-        vm.expectEmit(true, true, true, true);
-        emit BucketAssignedExercise(testOptionId, expectedBucketIndex, 789);
 
         vm.expectEmit(true, true, true, true);
         emit OptionsExercised(testOptionId, BOB, 3);

--- a/test/utils/BaseEngineTest.sol
+++ b/test/utils/BaseEngineTest.sol
@@ -404,7 +404,9 @@ abstract contract BaseEngineTest is Test {
         uint256 underlyingAmountRedeemed
     );
 
-    event BucketWrittenInto(uint256 indexed optionId, uint96 bucketIndex, uint112 amount);
+    event BucketWrittenInto(
+        uint256 indexed optionId, uint256 indexed claimId, uint96 indexed bucketIndex, uint112 amount
+    );
 
     event BucketAssignedExercise(uint256 indexed optionId, uint96 indexed bucketIndex, uint112 amountAssigned);
 

--- a/test/utils/BaseEngineTest.sol
+++ b/test/utils/BaseEngineTest.sol
@@ -394,7 +394,9 @@ abstract contract BaseEngineTest is Test {
         uint40 indexed expiryTimestamp
     );
 
-    event OptionsWritten(uint256 indexed optionId, address indexed writer, uint256 indexed claimId, uint112 amount);
+    event OptionsWritten(
+        uint256 indexed optionId, address indexed writer, uint256 indexed claimId, uint96 bucketIndex, uint112 amount
+    );
 
     event ClaimRedeemed(
         uint256 indexed claimId,
@@ -403,6 +405,8 @@ abstract contract BaseEngineTest is Test {
         uint256 exerciseAmountRedeemed,
         uint256 underlyingAmountRedeemed
     );
+
+    event BucketAssignedExercise(uint256 indexed optionId, uint96 indexed bucketIndex, uint112 amountAssigned);
 
     event OptionsExercised(uint256 indexed optionId, address indexed exerciser, uint112 amount);
 

--- a/test/utils/BaseEngineTest.sol
+++ b/test/utils/BaseEngineTest.sol
@@ -394,9 +394,7 @@ abstract contract BaseEngineTest is Test {
         uint40 indexed expiryTimestamp
     );
 
-    event OptionsWritten(
-        uint256 indexed optionId, address indexed writer, uint256 indexed claimId, uint96 bucketIndex, uint112 amount
-    );
+    event OptionsWritten(uint256 indexed optionId, address indexed writer, uint256 indexed claimId, uint112 amount);
 
     event ClaimRedeemed(
         uint256 indexed claimId,
@@ -405,6 +403,8 @@ abstract contract BaseEngineTest is Test {
         uint256 exerciseAmountRedeemed,
         uint256 underlyingAmountRedeemed
     );
+
+    event BucketWrittenInto(uint256 indexed optionId, uint96 bucketIndex, uint112 amount);
 
     event BucketAssignedExercise(uint256 indexed optionId, uint96 indexed bucketIndex, uint112 amountAssigned);
 


### PR DESCRIPTION
Proposed changes in this PR — 
- Add `BucketWrittenInto` event
- Add `BucketAssignedExercise` event

Will save for the more significant entropy and weighting PRs — 
- Write an additional test(s) to check which buckets are getting assigned in more complex situations